### PR TITLE
[PR] Set a specific auth cookie containing the user's AD groups

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -96,5 +96,5 @@ function ir_set_auth_cookies( $user, $user_ad_data ) {
 	$expire = time() + 1 * DAY_IN_SECONDS;
 	$secure = is_ssl();
 
-	setcookie( 'ir_ad_groups', $user_ad_groups, $expire, SITECOOKIEPATH, COOKIE_DOMAIN, $secure, true);
+	setcookie( 'ir_ad_groups', $user_ad_groups, $expire, SITECOOKIEPATH, COOKIE_DOMAIN, $secure, true );
 }

--- a/functions.php
+++ b/functions.php
@@ -78,3 +78,23 @@ function ir_set_upload_mimes( $mime_types ) {
 
 	return $mime_types;
 }
+
+add_action( 'wsuwp_sso_set_authentication', 'ir_set_auth_cookies', 10, 2 );
+/**
+ * Sets an additional cookie containing the user's AD group information
+ * after a successful authentication.
+ *
+ * @param WP_User $user
+ * @param array   $user_ad_data
+ */
+function ir_set_auth_cookies( $user, $user_ad_data ) {
+	if ( ! isset( $user_ad_data['memberof'] ) || empty( $user_ad_data['memberof'] ) ) {
+		return;
+	}
+
+	$user_ad_groups = implode( ',', $user_ad_data['memberof'] );
+	$expire = time() + 1 * DAY_IN_SECONDS;
+	$secure = is_ssl();
+
+	setcookie( 'ir_ad_groups', $user_ad_groups, $expire, SITECOOKIEPATH, COOKIE_DOMAIN, $secure, true);
+}


### PR DESCRIPTION
We'll use this cookie on the server to determine if a user should have access to a file.

This relies on the action in https://github.com/washingtonstateuniversity/WSUWP-Plugin-SSO-Authentication/pull/57