### PR TITLE
[PR] Restrict id_ad_groups cookie to specific AD groups

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -146,8 +146,8 @@ function ir_set_upload_mimes( $mime_types ) {
 
 add_action( 'wsuwp_sso_set_authentication', 'ir_set_auth_cookies', 10, 2 );
 /**
- * Sets an additional cookie containing the user's AD group information
- * after a successful authentication.
+ * Set an additional cookie after successful authentication containing the AD groups
+ * a user belongs to that are required to view certain content on ir.wsu.edu.
  *
  * @param WP_User $user
  * @param array   $user_ad_data
@@ -157,7 +157,28 @@ function ir_set_auth_cookies( $user, $user_ad_data ) {
 		return;
 	}
 
-	$user_ad_groups = implode( ',', $user_ad_data['memberof'] );
+	// List of AD groups used to restrict IR content.
+	$ir_ad_groups = array(
+		'IR_Managers',
+		'IR_Web_Users',
+		'IR_Admin',
+		'HRS_Appointing_Authority',
+		'Employees.Active.Courtesy',
+		'Employees.Active.Assistantship',
+		'Employees.Active.AdministrativeProfessional',
+		'Employees.Active.Faculty',
+		'Employees.Active.Hourly',
+		'Employees.Active.CivilService',
+	);
+
+	$user_ad_groups = array();
+	foreach( $user_ad_data['memberof'] as $group ) {
+		if ( in_array( $group, $ir_ad_groups, true ) ) {
+			$user_ad_groups[] = $group;
+		}
+	}
+
+	$user_ad_groups = implode( ',', $user_ad_groups );
 	$expire = time() + 1 * DAY_IN_SECONDS;
 	$secure = is_ssl();
 

--- a/functions.php
+++ b/functions.php
@@ -172,7 +172,7 @@ function ir_set_auth_cookies( $user, $user_ad_data ) {
 	);
 
 	$user_ad_groups = array();
-	foreach( $user_ad_data['memberof'] as $group ) {
+	foreach ( $user_ad_data['memberof'] as $group ) {
 		if ( in_array( $group, $ir_ad_groups, true ) ) {
 			$user_ad_groups[] = $group;
 		}


### PR DESCRIPTION
Cookies can only be a certain size before the request becomes a problem on the server or in the browser. For users that are members of many AD groups, the ir_ad_groups cookie gets large quickly.

We can restrict the groups in this cookie to only those that matter for access on ir.wsu.edu rather than all of the groups the user is a member of.